### PR TITLE
feat Added support for SecurityHub integration findings

### DIFF
--- a/awsfindingsmanagerlib/awsfindingsmanagerlib.py
+++ b/awsfindingsmanagerlib/awsfindingsmanagerlib.py
@@ -338,9 +338,9 @@ class Finding:
     def is_matching_rule(self, rule: Rule) -> bool:
         """Checks a rule for a match with the finding.
 
-        If any of control_id, security_control_id or rule_id attributes match between the rule and the finding and the
+        If any of control_id, security_control_id, rule_id or product_name attributes match between the rule and the finding and the
         rule does not have any filtering attributes like resource_id_regexps or tags then it is considered a match.
-        (Big blast radius) only matching on the control.
+        (Big blast radius) only matching on the control or product.
 
         If the rule has any attributes like resource_id_regexps or tags then a secondary match is searched for any of
         them with the corresponding finding attributes. If any match is found then the rule is found matching if none

--- a/awsfindingsmanagerlib/awsfindingsmanagerlib.py
+++ b/awsfindingsmanagerlib/awsfindingsmanagerlib.py
@@ -338,9 +338,9 @@ class Finding:
     def is_matching_rule(self, rule: Rule) -> bool:
         """Checks a rule for a match with the finding.
 
-        If any of control_id, security_control_id, rule_id or product_name attributes match between the rule and the finding and the
-        rule does not have any filtering attributes like resource_id_regexps or tags then it is considered a match.
-        (Big blast radius) only matching on the control or product.
+        If any of control_id, security_control_id, rule_id or product_name attributes match between the rule and the
+        finding and the rule does not have any filtering attributes like resource_id_regexps or tags then it is
+        considered a match. (Big blast radius) only matching on the control or product.
 
         If the rule has any attributes like resource_id_regexps or tags then a secondary match is searched for any of
         them with the corresponding finding attributes. If any match is found then the rule is found matching if none

--- a/awsfindingsmanagerlib/awsfindingsmanagerlib.py
+++ b/awsfindingsmanagerlib/awsfindingsmanagerlib.py
@@ -133,6 +133,11 @@ class Finding:
         return self._data.get('ProductArn')
 
     @property
+    def product_name(self) -> str:
+        """Product Name."""
+        return self._data.get('ProductName')
+
+    @property
     def region(self) -> str:
         """Region."""
         return self._data.get('Region')
@@ -357,10 +362,15 @@ class Finding:
             self.match_if_set(self.security_control_id,
                               rule.security_control_id),
             self.match_if_set(self.control_id, rule.rule_or_control_id),
-            self.match_if_set(self.rule_id, rule.rule_or_control_id)
+            self.match_if_set(self.rule_id, rule.rule_or_control_id),
+            self.match_if_set(self.product_name, rule.product_name),
         ]):
             self._logger.debug(
-                f'Matched with rule "{rule.note}" on one of "control_id, security_control_id"')
+                f'Matched with rule "{rule.note}" on one of "control_id, security_control_id, product_name"')
+            if self.match_if_set(self.title, rule.title):
+                self._logger.debug(
+                    f'Matched with rule "{rule.note}" on title.')
+                return True
             if not any([rule.tags, rule.resource_id_regexps]):
                 self._logger.debug(
                     f'Rule "{rule.note}" does not seem to have filters for resources or tags.')
@@ -412,6 +422,11 @@ class Rule:
         return self._data.get('match_on')
 
     @property
+    def product_name(self) -> str:
+        """The product name if any, empty string otherwise."""
+        return self.match_on.get('product_name', '')
+
+    @property
     def security_control_id(self) -> str:
         """The security control ID if any, empty string otherwise."""
         return self.match_on.get('security_control_id', '')
@@ -427,9 +442,31 @@ class Rule:
         return self.match_on.get('resource_id_regexps', [])
 
     @property
+    def title(self) -> str:
+        """The title if any, empty string otherwise."""
+        return self.match_on.get('title', '')
+
+    @property
     def tags(self) -> List[Optional[str]]:
         """The tags specified under the match_on attribute."""
         return self.match_on.get('tags', [])
+
+    @staticmethod
+    def _get_product_name_query(match_on_data) -> Dict:
+        """Constructs a valid query based on product name if any.
+
+        Args:
+            match_on_data: The match_on data of the Rule
+
+        Returns:
+             The query matching the product name, empty dictionary otherwise.
+
+        """
+        product_name = match_on_data.get('product_name')
+        if not product_name:
+            return {}
+        return {'ProductName': [{'Value': product_name,
+                                 'Comparison': 'EQUALS'}]}
 
     @staticmethod
     def _get_rule_or_control_id_query(match_on_data) -> Dict:
@@ -490,6 +527,23 @@ class Rule:
                                   'Comparison': 'EQUALS'}
                                  for tag in tags]}
 
+    @staticmethod
+    def _get_title_query(match_on_data) -> Dict:
+        """Constructs a valid query based on title if any.
+
+        Args:
+            match_on_data: The match_on data of the Rule
+
+        Returns:
+             The query matching the title, empty dictionary otherwise.
+
+        """
+        title = match_on_data.get('title')
+        if not title:
+            return {}
+        return {'Title': [{'Value': title,
+                           'Comparison': 'EQUALS'}]}
+
     @property
     def query_filter(self) -> Dict:
         """The query filter of the Rule based on all set attributes.
@@ -502,6 +556,8 @@ class Rule:
         query.update(self._get_rule_or_control_id_query(self.match_on))
         query.update(self._get_security_control_id_query(self.match_on))
         query.update(self._get_tag_query(self.match_on))
+        query.update(self._get_title_query(self.match_on))
+        query.update(self._get_product_name_query(self.match_on))
         return deepcopy(query)
 
 

--- a/awsfindingsmanagerlib/validations.py
+++ b/awsfindingsmanagerlib/validations.py
@@ -48,6 +48,8 @@ __email__ = '''<bvanbreukelen@schubergphilis.com>,<ctyfoxylos@schubergphilis.com
 __status__ = '''Development'''  # "Prototype", "Development", "Production".
 
 rule_schema = Schema({'match_on': {Optional('rule_or_control_id'): str,
+                                   Optional('title'): str,
+                                   Optional('product_name'): str,
                                    Optional('security_control_id'): str,
                                    Optional('resource_id_regexps'): [str],
                                    Optional('tags'): [{'key': str,

--- a/tests/fixtures/batch_update_findings_full.json
+++ b/tests/fixtures/batch_update_findings_full.json
@@ -59,5 +59,28 @@
       "Text": "MF-Neigh",
       "UpdatedBy": "FindingsManager"
     }
+  },
+  {
+    "FindingIdentifiers": [
+      {
+        "Id": "arn:aws:inspector2:eu-west-1:012345678912:finding/ff4ebfb9d83b0ee89c7140b30eed5ef9",
+        "ProductArn": "arn:aws:securityhub:eu-west-1::product/aws/inspector"
+      },
+      {
+        "Id": "arn:aws:inspector2:eu-west-1:012345678912:finding/ioperfb9d83b0ee89c7140b30eed5lf9",
+        "ProductArn": "arn:aws:securityhub:eu-west-1::product/aws/inspector"
+      },
+      {
+          "Id": "arn:aws:inspector2:eu-west-1:012345678912:finding/m58hv3b9d83b0ee89c7140b30eed55kv",
+          "ProductArn": "arn:aws:securityhub:eu-west-1::product/aws/inspector"
+      }
+    ],
+    "Workflow": {
+      "Status": "SUPPRESSED"
+    },
+    "Note": {
+      "Text": "We support Inspector too",
+      "UpdatedBy": "FindingsManager"
+    }
   }
 ]

--- a/tests/fixtures/findings/full/Inspector/acc.json
+++ b/tests/fixtures/findings/full/Inspector/acc.json
@@ -1,0 +1,154 @@
+{
+    "AwsAccountId": "012345678912",
+    "AwsAccountName": "account",
+    "CompanyName": "Amazon",
+    "CreatedAt": "2024-11-11T14:40:00.016Z",
+    "Description": "A flaw was found in python. An improperly handled HTTP response in the HTTP client code of python may allow a remote attacker, who controls the HTTP server, to make the client script enter an infinite loop, consuming CPU time. The highest threat from this vulnerability is to system availability.",
+    "FindingProviderFields": {
+        "Types": [
+            "Software and Configuration Checks/Vulnerabilities/CVE"
+        ],
+        "Severity": {
+            "Normalized": 70,
+            "Label": "HIGH"
+        }
+    },
+    "FirstObservedAt": "2024-11-11T14:40:00.016Z",
+    "GeneratorId": "AWSInspector",
+    "Id": "arn:aws:inspector2:eu-west-1:012345678912:finding/ioperfb9d83b0ee89c7140b30eed5lf9",
+    "LastObservedAt": "2024-11-11T14:40:00.016Z",
+    "ProcessedAt": "2024-11-11T14:45:08.567Z",
+    "ProductArn": "arn:aws:securityhub:eu-west-1::product/aws/inspector",
+    "ProductFields": {
+        "aws/inspector/ProductVersion": "2",
+        "aws/inspector/FindingStatus": "CLOSED",
+        "aws/inspector/inspectorScore": "7.5",
+        "aws/inspector/instanceId": "i-01e8db61387e018b4",
+        "aws/inspector/resources/1/resourceDetails/awsEc2InstanceDetails/platform": "UBUNTU_22_04",
+        "aws/securityhub/FindingId": "arn:aws:securityhub:eu-west-1::product/aws/inspector/arn:aws:inspector2:eu-west-1:012345678912:finding/ff4ebfb9d83b0ee89c7140b30eed5ef9",
+        "aws/securityhub/ProductName": "Inspector",
+        "aws/securityhub/CompanyName": "Amazon"
+    },
+    "ProductName": "Inspector",
+    "RecordState": "ARCHIVED",
+    "Region": "eu-west-1",
+    "Remediation": {
+        "Recommendation": {
+            "Text": "Remediation is available. Please refer to the Fixed version in the vulnerability details section above.For detailed remediation guidance for each of the affected packages, refer to the vulnerabilities section of the detailed finding JSON."
+        }
+    },
+    "Resources": [
+        {
+            "Details": {
+                "AwsEc2Instance": {
+                    "Type": "t3.large",
+                    "VpcId": "vpc-0d165124e6f1211e6",
+                    "ImageId": "ami-030c1a56dd9a0ccd8",
+                    "IpV4Addresses": [
+                        "192.168.0.74"
+                    ],
+                    "SubnetId": "subnet-062ae210766aa9614",
+                    "LaunchedAt": "2024-11-11T14:38:42.000Z",
+                    "IamInstanceProfileArn": "arn:aws:iam::012345678912:instance-profile/example/example-profile"
+                }
+            },
+            "Id": "arn:aws:ec2:eu-west-1:012345678912:instance/i-01e8db61387e018b4",
+            "Partition": "aws",
+            "Region": "eu-west-1",
+            "Tags": {
+                "aws:ec2:fleet-id": "fleet-28b70307-1da4-e616-0cb8-0d20555fe75c",
+                "ghr:environment": "example",
+                "aws:ec2launchtemplate:version": "9",
+                "aws:ec2launchtemplate:id": "lt-0c064043433a6dcfe",
+                "Name": "example-action-runner"
+            },
+            "Type": "AwsEc2Instance"
+        }
+    ],
+    "SchemaVersion": "2018-10-08",
+    "Severity": {
+        "Label": "HIGH",
+        "Normalized": 70
+    },
+    "Title": "CVE-2021-3737 - python3.10, python3.10-minimal",
+    "Types": [
+        "Software and Configuration Checks/Vulnerabilities/CVE"
+    ],
+    "UpdatedAt": "2024-11-11T14:44:51.175Z",
+    "Vulnerabilities": [
+        {
+            "Cvss": [
+                {
+                    "BaseScore": 7.5,
+                    "BaseVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                    "Source": "UBUNTU_CVE",
+                    "Version": "3.1"
+                },
+                {
+                    "BaseScore": 7.5,
+                    "BaseVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                    "Source": "NVD",
+                    "Version": "3.1"
+                },
+                {
+                    "BaseScore": 7.5,
+                    "BaseVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                    "Source": "UBUNTU_CVE",
+                    "Version": "3.1"
+                }
+            ],
+            "EpssScore": 0.01559,
+            "ExploitAvailable": "NO",
+            "FixAvailable": "YES",
+            "Id": "CVE-2021-3737",
+            "ReferenceUrls": [
+                "https://ubuntu.com/security/notices/USN-5083-1",
+                "https://ubuntu.com/security/notices/USN-5201-1",
+                "https://ubuntu.com/security/notices/USN-5200-1",
+                "https://ubuntu.com/security/notices/USN-6891-1",
+                "https://bugs.python.org/issue44022",
+                "https://www.cve.org/CVERecord?id=CVE-2021-3737",
+                "https://ubuntu.com/security/notices/USN-5199-1"
+            ],
+            "RelatedVulnerabilities": [
+                "USN-5200-1",
+                "USN-5201-1",
+                "USN-5083-1",
+                "USN-6891-1",
+                "USN-5199-1"
+            ],
+            "Vendor": {
+                "VendorCreatedAt": "2022-03-04T19:15:00.000Z",
+                "VendorSeverity": "medium",
+                "Url": "https://people.canonical.com/~ubuntu-security/cve/2021/CVE-2021-3737.html",
+                "Name": "UBUNTU_CVE"
+            },
+            "VulnerablePackages": [
+                {
+                    "Architecture": "X86_64",
+                    "PackageManager": "OS",
+                    "Version": "3.10.6",
+                    "Epoch": "0",
+                    "FixedInVersion": "0:3.10.12-1~22.04.4",
+                    "Remediation": "apt-get update && apt-get upgrade",
+                    "Release": "1~22.04.2ubuntu1.1",
+                    "Name": "python3.10"
+                },
+                {
+                    "Architecture": "X86_64",
+                    "PackageManager": "OS",
+                    "Version": "3.10.6",
+                    "Epoch": "0",
+                    "FixedInVersion": "0:3.10.12-1~22.04.4",
+                    "Remediation": "apt-get update && apt-get upgrade",
+                    "Release": "1~22.04.2ubuntu1.1",
+                    "Name": "python3.10-minimal"
+                }
+            ]
+        }
+    ],
+    "Workflow": {
+        "Status": "NEW"
+    },
+    "WorkflowState": "NEW"
+}

--- a/tests/fixtures/findings/full/Inspector/dev.json
+++ b/tests/fixtures/findings/full/Inspector/dev.json
@@ -1,0 +1,154 @@
+{
+    "AwsAccountId": "012345678912",
+    "AwsAccountName": "account",
+    "CompanyName": "Amazon",
+    "CreatedAt": "2024-11-11T14:40:00.016Z",
+    "Description": "A flaw was found in python. An improperly handled HTTP response in the HTTP client code of python may allow a remote attacker, who controls the HTTP server, to make the client script enter an infinite loop, consuming CPU time. The highest threat from this vulnerability is to system availability.",
+    "FindingProviderFields": {
+        "Types": [
+            "Software and Configuration Checks/Vulnerabilities/CVE"
+        ],
+        "Severity": {
+            "Normalized": 70,
+            "Label": "HIGH"
+        }
+    },
+    "FirstObservedAt": "2024-11-11T14:40:00.016Z",
+    "GeneratorId": "AWSInspector",
+    "Id": "arn:aws:inspector2:eu-west-1:012345678912:finding/ff4ebfb9d83b0ee89c7140b30eed5ef9",
+    "LastObservedAt": "2024-11-11T14:40:00.016Z",
+    "ProcessedAt": "2024-11-11T14:45:08.567Z",
+    "ProductArn": "arn:aws:securityhub:eu-west-1::product/aws/inspector",
+    "ProductFields": {
+        "aws/inspector/ProductVersion": "2",
+        "aws/inspector/FindingStatus": "CLOSED",
+        "aws/inspector/inspectorScore": "7.5",
+        "aws/inspector/instanceId": "i-01e8db61387e018b4",
+        "aws/inspector/resources/1/resourceDetails/awsEc2InstanceDetails/platform": "UBUNTU_22_04",
+        "aws/securityhub/FindingId": "arn:aws:securityhub:eu-west-1::product/aws/inspector/arn:aws:inspector2:eu-west-1:012345678912:finding/ff4ebfb9d83b0ee89c7140b30eed5ef9",
+        "aws/securityhub/ProductName": "Inspector",
+        "aws/securityhub/CompanyName": "Amazon"
+    },
+    "ProductName": "Inspector",
+    "RecordState": "ARCHIVED",
+    "Region": "eu-west-1",
+    "Remediation": {
+        "Recommendation": {
+            "Text": "Remediation is available. Please refer to the Fixed version in the vulnerability details section above.For detailed remediation guidance for each of the affected packages, refer to the vulnerabilities section of the detailed finding JSON."
+        }
+    },
+    "Resources": [
+        {
+            "Details": {
+                "AwsEc2Instance": {
+                    "Type": "t3.large",
+                    "VpcId": "vpc-0d165124e6f1211e6",
+                    "ImageId": "ami-030c1a56dd9a0ccd8",
+                    "IpV4Addresses": [
+                        "192.168.0.74"
+                    ],
+                    "SubnetId": "subnet-062ae210766aa9614",
+                    "LaunchedAt": "2024-11-11T14:38:42.000Z",
+                    "IamInstanceProfileArn": "arn:aws:iam::012345678912:instance-profile/example/example-profile"
+                }
+            },
+            "Id": "arn:aws:ec2:eu-west-1:012345678912:instance/i-01e8db61387e018b4",
+            "Partition": "aws",
+            "Region": "eu-west-1",
+            "Tags": {
+                "aws:ec2:fleet-id": "fleet-28b70307-1da4-e616-0cb8-0d20555fe75c",
+                "ghr:environment": "example",
+                "aws:ec2launchtemplate:version": "9",
+                "aws:ec2launchtemplate:id": "lt-0c064043433a6dcfe",
+                "Name": "example-action-runner"
+            },
+            "Type": "AwsEc2Instance"
+        }
+    ],
+    "SchemaVersion": "2018-10-08",
+    "Severity": {
+        "Label": "HIGH",
+        "Normalized": 70
+    },
+    "Title": "CVE-2021-3737 - python3.10, python3.10-minimal",
+    "Types": [
+        "Software and Configuration Checks/Vulnerabilities/CVE"
+    ],
+    "UpdatedAt": "2024-11-11T14:44:51.175Z",
+    "Vulnerabilities": [
+        {
+            "Cvss": [
+                {
+                    "BaseScore": 7.5,
+                    "BaseVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                    "Source": "UBUNTU_CVE",
+                    "Version": "3.1"
+                },
+                {
+                    "BaseScore": 7.5,
+                    "BaseVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                    "Source": "NVD",
+                    "Version": "3.1"
+                },
+                {
+                    "BaseScore": 7.5,
+                    "BaseVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                    "Source": "UBUNTU_CVE",
+                    "Version": "3.1"
+                }
+            ],
+            "EpssScore": 0.01559,
+            "ExploitAvailable": "NO",
+            "FixAvailable": "YES",
+            "Id": "CVE-2021-3737",
+            "ReferenceUrls": [
+                "https://ubuntu.com/security/notices/USN-5083-1",
+                "https://ubuntu.com/security/notices/USN-5201-1",
+                "https://ubuntu.com/security/notices/USN-5200-1",
+                "https://ubuntu.com/security/notices/USN-6891-1",
+                "https://bugs.python.org/issue44022",
+                "https://www.cve.org/CVERecord?id=CVE-2021-3737",
+                "https://ubuntu.com/security/notices/USN-5199-1"
+            ],
+            "RelatedVulnerabilities": [
+                "USN-5200-1",
+                "USN-5201-1",
+                "USN-5083-1",
+                "USN-6891-1",
+                "USN-5199-1"
+            ],
+            "Vendor": {
+                "VendorCreatedAt": "2022-03-04T19:15:00.000Z",
+                "VendorSeverity": "medium",
+                "Url": "https://people.canonical.com/~ubuntu-security/cve/2021/CVE-2021-3737.html",
+                "Name": "UBUNTU_CVE"
+            },
+            "VulnerablePackages": [
+                {
+                    "Architecture": "X86_64",
+                    "PackageManager": "OS",
+                    "Version": "3.10.6",
+                    "Epoch": "0",
+                    "FixedInVersion": "0:3.10.12-1~22.04.4",
+                    "Remediation": "apt-get update && apt-get upgrade",
+                    "Release": "1~22.04.2ubuntu1.1",
+                    "Name": "python3.10"
+                },
+                {
+                    "Architecture": "X86_64",
+                    "PackageManager": "OS",
+                    "Version": "3.10.6",
+                    "Epoch": "0",
+                    "FixedInVersion": "0:3.10.12-1~22.04.4",
+                    "Remediation": "apt-get update && apt-get upgrade",
+                    "Release": "1~22.04.2ubuntu1.1",
+                    "Name": "python3.10-minimal"
+                }
+            ]
+        }
+    ],
+    "Workflow": {
+        "Status": "NEW"
+    },
+    "WorkflowState": "NEW"
+}

--- a/tests/fixtures/findings/full/Inspector/prd.json
+++ b/tests/fixtures/findings/full/Inspector/prd.json
@@ -1,0 +1,154 @@
+{
+    "AwsAccountId": "012345678912",
+    "AwsAccountName": "account",
+    "CompanyName": "Amazon",
+    "CreatedAt": "2024-11-11T14:40:00.016Z",
+    "Description": "A flaw was found in python. An improperly handled HTTP response in the HTTP client code of python may allow a remote attacker, who controls the HTTP server, to make the client script enter an infinite loop, consuming CPU time. The highest threat from this vulnerability is to system availability.",
+    "FindingProviderFields": {
+        "Types": [
+            "Software and Configuration Checks/Vulnerabilities/CVE"
+        ],
+        "Severity": {
+            "Normalized": 70,
+            "Label": "HIGH"
+        }
+    },
+    "FirstObservedAt": "2024-11-11T14:40:00.016Z",
+    "GeneratorId": "AWSInspector",
+    "Id": "arn:aws:inspector2:eu-west-1:012345678912:finding/m58hv3b9d83b0ee89c7140b30eed55kv",
+    "LastObservedAt": "2024-11-11T14:40:00.016Z",
+    "ProcessedAt": "2024-11-11T14:45:08.567Z",
+    "ProductArn": "arn:aws:securityhub:eu-west-1::product/aws/inspector",
+    "ProductFields": {
+        "aws/inspector/ProductVersion": "2",
+        "aws/inspector/FindingStatus": "CLOSED",
+        "aws/inspector/inspectorScore": "7.5",
+        "aws/inspector/instanceId": "i-01e8db61387e018b4",
+        "aws/inspector/resources/1/resourceDetails/awsEc2InstanceDetails/platform": "UBUNTU_22_04",
+        "aws/securityhub/FindingId": "arn:aws:securityhub:eu-west-1::product/aws/inspector/arn:aws:inspector2:eu-west-1:012345678912:finding/ff4ebfb9d83b0ee89c7140b30eed5ef9",
+        "aws/securityhub/ProductName": "Inspector",
+        "aws/securityhub/CompanyName": "Amazon"
+    },
+    "ProductName": "Inspector",
+    "RecordState": "ARCHIVED",
+    "Region": "eu-west-1",
+    "Remediation": {
+        "Recommendation": {
+            "Text": "Remediation is available. Please refer to the Fixed version in the vulnerability details section above.For detailed remediation guidance for each of the affected packages, refer to the vulnerabilities section of the detailed finding JSON."
+        }
+    },
+    "Resources": [
+        {
+            "Details": {
+                "AwsEc2Instance": {
+                    "Type": "t3.large",
+                    "VpcId": "vpc-0d165124e6f1211e6",
+                    "ImageId": "ami-030c1a56dd9a0ccd8",
+                    "IpV4Addresses": [
+                        "192.168.0.74"
+                    ],
+                    "SubnetId": "subnet-062ae210766aa9614",
+                    "LaunchedAt": "2024-11-11T14:38:42.000Z",
+                    "IamInstanceProfileArn": "arn:aws:iam::012345678912:instance-profile/example/example-profile"
+                }
+            },
+            "Id": "arn:aws:ec2:eu-west-1:012345678912:instance/i-01e8db61387e018b4",
+            "Partition": "aws",
+            "Region": "eu-west-1",
+            "Tags": {
+                "aws:ec2:fleet-id": "fleet-28b70307-1da4-e616-0cb8-0d20555fe75c",
+                "ghr:environment": "example",
+                "aws:ec2launchtemplate:version": "9",
+                "aws:ec2launchtemplate:id": "lt-0c064043433a6dcfe",
+                "Name": "example-action-runner"
+            },
+            "Type": "AwsEc2Instance"
+        }
+    ],
+    "SchemaVersion": "2018-10-08",
+    "Severity": {
+        "Label": "HIGH",
+        "Normalized": 70
+    },
+    "Title": "CVE-2021-3737 - python3.10, python3.10-minimal",
+    "Types": [
+        "Software and Configuration Checks/Vulnerabilities/CVE"
+    ],
+    "UpdatedAt": "2024-11-11T14:44:51.175Z",
+    "Vulnerabilities": [
+        {
+            "Cvss": [
+                {
+                    "BaseScore": 7.5,
+                    "BaseVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                    "Source": "UBUNTU_CVE",
+                    "Version": "3.1"
+                },
+                {
+                    "BaseScore": 7.5,
+                    "BaseVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                    "Source": "NVD",
+                    "Version": "3.1"
+                },
+                {
+                    "BaseScore": 7.5,
+                    "BaseVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                    "Source": "UBUNTU_CVE",
+                    "Version": "3.1"
+                }
+            ],
+            "EpssScore": 0.01559,
+            "ExploitAvailable": "NO",
+            "FixAvailable": "YES",
+            "Id": "CVE-2021-3737",
+            "ReferenceUrls": [
+                "https://ubuntu.com/security/notices/USN-5083-1",
+                "https://ubuntu.com/security/notices/USN-5201-1",
+                "https://ubuntu.com/security/notices/USN-5200-1",
+                "https://ubuntu.com/security/notices/USN-6891-1",
+                "https://bugs.python.org/issue44022",
+                "https://www.cve.org/CVERecord?id=CVE-2021-3737",
+                "https://ubuntu.com/security/notices/USN-5199-1"
+            ],
+            "RelatedVulnerabilities": [
+                "USN-5200-1",
+                "USN-5201-1",
+                "USN-5083-1",
+                "USN-6891-1",
+                "USN-5199-1"
+            ],
+            "Vendor": {
+                "VendorCreatedAt": "2022-03-04T19:15:00.000Z",
+                "VendorSeverity": "medium",
+                "Url": "https://people.canonical.com/~ubuntu-security/cve/2021/CVE-2021-3737.html",
+                "Name": "UBUNTU_CVE"
+            },
+            "VulnerablePackages": [
+                {
+                    "Architecture": "X86_64",
+                    "PackageManager": "OS",
+                    "Version": "3.10.6",
+                    "Epoch": "0",
+                    "FixedInVersion": "0:3.10.12-1~22.04.4",
+                    "Remediation": "apt-get update && apt-get upgrade",
+                    "Release": "1~22.04.2ubuntu1.1",
+                    "Name": "python3.10"
+                },
+                {
+                    "Architecture": "X86_64",
+                    "PackageManager": "OS",
+                    "Version": "3.10.6",
+                    "Epoch": "0",
+                    "FixedInVersion": "0:3.10.12-1~22.04.4",
+                    "Remediation": "apt-get update && apt-get upgrade",
+                    "Release": "1~22.04.2ubuntu1.1",
+                    "Name": "python3.10-minimal"
+                }
+            ]
+        }
+    ],
+    "Workflow": {
+        "Status": "NEW"
+    },
+    "WorkflowState": "NEW"
+}

--- a/tests/fixtures/matches.json
+++ b/tests/fixtures/matches.json
@@ -749,5 +749,500 @@
     },
     "ProcessedAt": "2024-07-24T19:05:12.057Z",
     "AwsAccountName": "watcher"
+  },
+  {
+    "matched_rule": {
+        "note": "We support Inspector too",
+        "action": "SUPPRESSED",
+        "match_on": {
+            "product_name": "Inspector",
+            "title": "CVE-2021-3737 - python3.10, python3.10-minimal",
+            "resource_id_regexps": [
+                "^arn:aws:ec2:.*:.*:instance/.*$"
+            ]
+        }
+    },
+    "AwsAccountId": "012345678912",
+    "AwsAccountName": "account",
+    "CompanyName": "Amazon",
+    "CreatedAt": "2024-11-11T14:40:00.016Z",
+    "Description": "A flaw was found in python. An improperly handled HTTP response in the HTTP client code of python may allow a remote attacker, who controls the HTTP server, to make the client script enter an infinite loop, consuming CPU time. The highest threat from this vulnerability is to system availability.",
+    "FindingProviderFields": {
+        "Types": [
+            "Software and Configuration Checks/Vulnerabilities/CVE"
+        ],
+        "Severity": {
+            "Normalized": 70,
+            "Label": "HIGH"
+        }
+    },
+    "FirstObservedAt": "2024-11-11T14:40:00.016Z",
+    "GeneratorId": "AWSInspector",
+    "Id": "arn:aws:inspector2:eu-west-1:012345678912:finding/ff4ebfb9d83b0ee89c7140b30eed5ef9",
+    "LastObservedAt": "2024-11-11T14:40:00.016Z",
+    "ProcessedAt": "2024-11-11T14:45:08.567Z",
+    "ProductArn": "arn:aws:securityhub:eu-west-1::product/aws/inspector",
+    "ProductFields": {
+        "aws/inspector/ProductVersion": "2",
+        "aws/inspector/FindingStatus": "CLOSED",
+        "aws/inspector/inspectorScore": "7.5",
+        "aws/inspector/instanceId": "i-01e8db61387e018b4",
+        "aws/inspector/resources/1/resourceDetails/awsEc2InstanceDetails/platform": "UBUNTU_22_04",
+        "aws/securityhub/FindingId": "arn:aws:securityhub:eu-west-1::product/aws/inspector/arn:aws:inspector2:eu-west-1:012345678912:finding/ff4ebfb9d83b0ee89c7140b30eed5ef9",
+        "aws/securityhub/ProductName": "Inspector",
+        "aws/securityhub/CompanyName": "Amazon"
+    },
+    "ProductName": "Inspector",
+    "RecordState": "ARCHIVED",
+    "Region": "eu-west-1",
+    "Remediation": {
+        "Recommendation": {
+            "Text": "Remediation is available. Please refer to the Fixed version in the vulnerability details section above.For detailed remediation guidance for each of the affected packages, refer to the vulnerabilities section of the detailed finding JSON."
+        }
+    },
+    "Resources": [
+        {
+            "Details": {
+                "AwsEc2Instance": {
+                    "Type": "t3.large",
+                    "VpcId": "vpc-0d165124e6f1211e6",
+                    "ImageId": "ami-030c1a56dd9a0ccd8",
+                    "IpV4Addresses": [
+                        "192.168.0.74"
+                    ],
+                    "SubnetId": "subnet-062ae210766aa9614",
+                    "LaunchedAt": "2024-11-11T14:38:42.000Z",
+                    "IamInstanceProfileArn": "arn:aws:iam::012345678912:instance-profile/example/example-profile"
+                }
+            },
+            "Id": "arn:aws:ec2:eu-west-1:012345678912:instance/i-01e8db61387e018b4",
+            "Partition": "aws",
+            "Region": "eu-west-1",
+            "Tags": {
+                "aws:ec2:fleet-id": "fleet-28b70307-1da4-e616-0cb8-0d20555fe75c",
+                "ghr:environment": "example",
+                "aws:ec2launchtemplate:version": "9",
+                "aws:ec2launchtemplate:id": "lt-0c064043433a6dcfe",
+                "Name": "example-action-runner"
+            },
+            "Type": "AwsEc2Instance"
+        }
+    ],
+    "SchemaVersion": "2018-10-08",
+    "Severity": {
+        "Label": "HIGH",
+        "Normalized": 70
+    },
+    "Title": "CVE-2021-3737 - python3.10, python3.10-minimal",
+    "Types": [
+        "Software and Configuration Checks/Vulnerabilities/CVE"
+    ],
+    "UpdatedAt": "2024-11-11T14:44:51.175Z",
+    "Vulnerabilities": [
+        {
+            "Cvss": [
+                {
+                    "BaseScore": 7.5,
+                    "BaseVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                    "Source": "UBUNTU_CVE",
+                    "Version": "3.1"
+                },
+                {
+                    "BaseScore": 7.5,
+                    "BaseVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                    "Source": "NVD",
+                    "Version": "3.1"
+                },
+                {
+                    "BaseScore": 7.5,
+                    "BaseVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                    "Source": "UBUNTU_CVE",
+                    "Version": "3.1"
+                }
+            ],
+            "EpssScore": 0.01559,
+            "ExploitAvailable": "NO",
+            "FixAvailable": "YES",
+            "Id": "CVE-2021-3737",
+            "ReferenceUrls": [
+                "https://ubuntu.com/security/notices/USN-5083-1",
+                "https://ubuntu.com/security/notices/USN-5201-1",
+                "https://ubuntu.com/security/notices/USN-5200-1",
+                "https://ubuntu.com/security/notices/USN-6891-1",
+                "https://bugs.python.org/issue44022",
+                "https://www.cve.org/CVERecord?id=CVE-2021-3737",
+                "https://ubuntu.com/security/notices/USN-5199-1"
+            ],
+            "RelatedVulnerabilities": [
+                "USN-5200-1",
+                "USN-5201-1",
+                "USN-5083-1",
+                "USN-6891-1",
+                "USN-5199-1"
+            ],
+            "Vendor": {
+                "VendorCreatedAt": "2022-03-04T19:15:00.000Z",
+                "VendorSeverity": "medium",
+                "Url": "https://people.canonical.com/~ubuntu-security/cve/2021/CVE-2021-3737.html",
+                "Name": "UBUNTU_CVE"
+            },
+            "VulnerablePackages": [
+                {
+                    "Architecture": "X86_64",
+                    "PackageManager": "OS",
+                    "Version": "3.10.6",
+                    "Epoch": "0",
+                    "FixedInVersion": "0:3.10.12-1~22.04.4",
+                    "Remediation": "apt-get update && apt-get upgrade",
+                    "Release": "1~22.04.2ubuntu1.1",
+                    "Name": "python3.10"
+                },
+                {
+                    "Architecture": "X86_64",
+                    "PackageManager": "OS",
+                    "Version": "3.10.6",
+                    "Epoch": "0",
+                    "FixedInVersion": "0:3.10.12-1~22.04.4",
+                    "Remediation": "apt-get update && apt-get upgrade",
+                    "Release": "1~22.04.2ubuntu1.1",
+                    "Name": "python3.10-minimal"
+                }
+            ]
+        }
+    ],
+    "Workflow": {
+        "Status": "NEW"
+    },
+    "WorkflowState": "NEW"
+  },
+  {
+    "matched_rule": {
+        "note": "We support Inspector too",
+        "action": "SUPPRESSED",
+        "match_on": {
+            "product_name": "Inspector",
+            "title": "CVE-2021-3737 - python3.10, python3.10-minimal",
+            "resource_id_regexps": [
+                "^arn:aws:ec2:.*:.*:instance/.*$"
+            ]
+        }
+    },
+    "AwsAccountId": "012345678912",
+    "AwsAccountName": "account",
+    "CompanyName": "Amazon",
+    "CreatedAt": "2024-11-11T14:40:00.016Z",
+    "Description": "A flaw was found in python. An improperly handled HTTP response in the HTTP client code of python may allow a remote attacker, who controls the HTTP server, to make the client script enter an infinite loop, consuming CPU time. The highest threat from this vulnerability is to system availability.",
+    "FindingProviderFields": {
+        "Types": [
+            "Software and Configuration Checks/Vulnerabilities/CVE"
+        ],
+        "Severity": {
+            "Normalized": 70,
+            "Label": "HIGH"
+        }
+    },
+    "FirstObservedAt": "2024-11-11T14:40:00.016Z",
+    "GeneratorId": "AWSInspector",
+    "Id": "arn:aws:inspector2:eu-west-1:012345678912:finding/ioperfb9d83b0ee89c7140b30eed5lf9",
+    "LastObservedAt": "2024-11-11T14:40:00.016Z",
+    "ProcessedAt": "2024-11-11T14:45:08.567Z",
+    "ProductArn": "arn:aws:securityhub:eu-west-1::product/aws/inspector",
+    "ProductFields": {
+        "aws/inspector/ProductVersion": "2",
+        "aws/inspector/FindingStatus": "CLOSED",
+        "aws/inspector/inspectorScore": "7.5",
+        "aws/inspector/instanceId": "i-01e8db61387e018b4",
+        "aws/inspector/resources/1/resourceDetails/awsEc2InstanceDetails/platform": "UBUNTU_22_04",
+        "aws/securityhub/FindingId": "arn:aws:securityhub:eu-west-1::product/aws/inspector/arn:aws:inspector2:eu-west-1:012345678912:finding/ff4ebfb9d83b0ee89c7140b30eed5ef9",
+        "aws/securityhub/ProductName": "Inspector",
+        "aws/securityhub/CompanyName": "Amazon"
+    },
+    "ProductName": "Inspector",
+    "RecordState": "ARCHIVED",
+    "Region": "eu-west-1",
+    "Remediation": {
+        "Recommendation": {
+            "Text": "Remediation is available. Please refer to the Fixed version in the vulnerability details section above.For detailed remediation guidance for each of the affected packages, refer to the vulnerabilities section of the detailed finding JSON."
+        }
+    },
+    "Resources": [
+        {
+            "Details": {
+                "AwsEc2Instance": {
+                    "Type": "t3.large",
+                    "VpcId": "vpc-0d165124e6f1211e6",
+                    "ImageId": "ami-030c1a56dd9a0ccd8",
+                    "IpV4Addresses": [
+                        "192.168.0.74"
+                    ],
+                    "SubnetId": "subnet-062ae210766aa9614",
+                    "LaunchedAt": "2024-11-11T14:38:42.000Z",
+                    "IamInstanceProfileArn": "arn:aws:iam::012345678912:instance-profile/example/example-profile"
+                }
+            },
+            "Id": "arn:aws:ec2:eu-west-1:012345678912:instance/i-01e8db61387e018b4",
+            "Partition": "aws",
+            "Region": "eu-west-1",
+            "Tags": {
+                "aws:ec2:fleet-id": "fleet-28b70307-1da4-e616-0cb8-0d20555fe75c",
+                "ghr:environment": "example",
+                "aws:ec2launchtemplate:version": "9",
+                "aws:ec2launchtemplate:id": "lt-0c064043433a6dcfe",
+                "Name": "example-action-runner"
+            },
+            "Type": "AwsEc2Instance"
+        }
+    ],
+    "SchemaVersion": "2018-10-08",
+    "Severity": {
+        "Label": "HIGH",
+        "Normalized": 70
+    },
+    "Title": "CVE-2021-3737 - python3.10, python3.10-minimal",
+    "Types": [
+        "Software and Configuration Checks/Vulnerabilities/CVE"
+    ],
+    "UpdatedAt": "2024-11-11T14:44:51.175Z",
+    "Vulnerabilities": [
+        {
+            "Cvss": [
+                {
+                    "BaseScore": 7.5,
+                    "BaseVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                    "Source": "UBUNTU_CVE",
+                    "Version": "3.1"
+                },
+                {
+                    "BaseScore": 7.5,
+                    "BaseVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                    "Source": "NVD",
+                    "Version": "3.1"
+                },
+                {
+                    "BaseScore": 7.5,
+                    "BaseVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                    "Source": "UBUNTU_CVE",
+                    "Version": "3.1"
+                }
+            ],
+            "EpssScore": 0.01559,
+            "ExploitAvailable": "NO",
+            "FixAvailable": "YES",
+            "Id": "CVE-2021-3737",
+            "ReferenceUrls": [
+                "https://ubuntu.com/security/notices/USN-5083-1",
+                "https://ubuntu.com/security/notices/USN-5201-1",
+                "https://ubuntu.com/security/notices/USN-5200-1",
+                "https://ubuntu.com/security/notices/USN-6891-1",
+                "https://bugs.python.org/issue44022",
+                "https://www.cve.org/CVERecord?id=CVE-2021-3737",
+                "https://ubuntu.com/security/notices/USN-5199-1"
+            ],
+            "RelatedVulnerabilities": [
+                "USN-5200-1",
+                "USN-5201-1",
+                "USN-5083-1",
+                "USN-6891-1",
+                "USN-5199-1"
+            ],
+            "Vendor": {
+                "VendorCreatedAt": "2022-03-04T19:15:00.000Z",
+                "VendorSeverity": "medium",
+                "Url": "https://people.canonical.com/~ubuntu-security/cve/2021/CVE-2021-3737.html",
+                "Name": "UBUNTU_CVE"
+            },
+            "VulnerablePackages": [
+                {
+                    "Architecture": "X86_64",
+                    "PackageManager": "OS",
+                    "Version": "3.10.6",
+                    "Epoch": "0",
+                    "FixedInVersion": "0:3.10.12-1~22.04.4",
+                    "Remediation": "apt-get update && apt-get upgrade",
+                    "Release": "1~22.04.2ubuntu1.1",
+                    "Name": "python3.10"
+                },
+                {
+                    "Architecture": "X86_64",
+                    "PackageManager": "OS",
+                    "Version": "3.10.6",
+                    "Epoch": "0",
+                    "FixedInVersion": "0:3.10.12-1~22.04.4",
+                    "Remediation": "apt-get update && apt-get upgrade",
+                    "Release": "1~22.04.2ubuntu1.1",
+                    "Name": "python3.10-minimal"
+                }
+            ]
+        }
+    ],
+    "Workflow": {
+        "Status": "NEW"
+    },
+    "WorkflowState": "NEW"
+  },
+  {
+    "matched_rule": {
+        "note": "We support Inspector too",
+        "action": "SUPPRESSED",
+        "match_on": {
+            "product_name": "Inspector",
+            "title": "CVE-2021-3737 - python3.10, python3.10-minimal",
+            "resource_id_regexps": [
+                "^arn:aws:ec2:.*:.*:instance/.*$"
+            ]
+        }
+    },
+    "AwsAccountId": "012345678912",
+    "AwsAccountName": "account",
+    "CompanyName": "Amazon",
+    "CreatedAt": "2024-11-11T14:40:00.016Z",
+    "Description": "A flaw was found in python. An improperly handled HTTP response in the HTTP client code of python may allow a remote attacker, who controls the HTTP server, to make the client script enter an infinite loop, consuming CPU time. The highest threat from this vulnerability is to system availability.",
+    "FindingProviderFields": {
+        "Types": [
+            "Software and Configuration Checks/Vulnerabilities/CVE"
+        ],
+        "Severity": {
+            "Normalized": 70,
+            "Label": "HIGH"
+        }
+    },
+    "FirstObservedAt": "2024-11-11T14:40:00.016Z",
+    "GeneratorId": "AWSInspector",
+    "Id": "arn:aws:inspector2:eu-west-1:012345678912:finding/m58hv3b9d83b0ee89c7140b30eed55kv",
+    "LastObservedAt": "2024-11-11T14:40:00.016Z",
+    "ProcessedAt": "2024-11-11T14:45:08.567Z",
+    "ProductArn": "arn:aws:securityhub:eu-west-1::product/aws/inspector",
+    "ProductFields": {
+        "aws/inspector/ProductVersion": "2",
+        "aws/inspector/FindingStatus": "CLOSED",
+        "aws/inspector/inspectorScore": "7.5",
+        "aws/inspector/instanceId": "i-01e8db61387e018b4",
+        "aws/inspector/resources/1/resourceDetails/awsEc2InstanceDetails/platform": "UBUNTU_22_04",
+        "aws/securityhub/FindingId": "arn:aws:securityhub:eu-west-1::product/aws/inspector/arn:aws:inspector2:eu-west-1:012345678912:finding/ff4ebfb9d83b0ee89c7140b30eed5ef9",
+        "aws/securityhub/ProductName": "Inspector",
+        "aws/securityhub/CompanyName": "Amazon"
+    },
+    "ProductName": "Inspector",
+    "RecordState": "ARCHIVED",
+    "Region": "eu-west-1",
+    "Remediation": {
+        "Recommendation": {
+            "Text": "Remediation is available. Please refer to the Fixed version in the vulnerability details section above.For detailed remediation guidance for each of the affected packages, refer to the vulnerabilities section of the detailed finding JSON."
+        }
+    },
+    "Resources": [
+        {
+            "Details": {
+                "AwsEc2Instance": {
+                    "Type": "t3.large",
+                    "VpcId": "vpc-0d165124e6f1211e6",
+                    "ImageId": "ami-030c1a56dd9a0ccd8",
+                    "IpV4Addresses": [
+                        "192.168.0.74"
+                    ],
+                    "SubnetId": "subnet-062ae210766aa9614",
+                    "LaunchedAt": "2024-11-11T14:38:42.000Z",
+                    "IamInstanceProfileArn": "arn:aws:iam::012345678912:instance-profile/example/example-profile"
+                }
+            },
+            "Id": "arn:aws:ec2:eu-west-1:012345678912:instance/i-01e8db61387e018b4",
+            "Partition": "aws",
+            "Region": "eu-west-1",
+            "Tags": {
+                "aws:ec2:fleet-id": "fleet-28b70307-1da4-e616-0cb8-0d20555fe75c",
+                "ghr:environment": "example",
+                "aws:ec2launchtemplate:version": "9",
+                "aws:ec2launchtemplate:id": "lt-0c064043433a6dcfe",
+                "Name": "example-action-runner"
+            },
+            "Type": "AwsEc2Instance"
+        }
+    ],
+    "SchemaVersion": "2018-10-08",
+    "Severity": {
+        "Label": "HIGH",
+        "Normalized": 70
+    },
+    "Title": "CVE-2021-3737 - python3.10, python3.10-minimal",
+    "Types": [
+        "Software and Configuration Checks/Vulnerabilities/CVE"
+    ],
+    "UpdatedAt": "2024-11-11T14:44:51.175Z",
+    "Vulnerabilities": [
+        {
+            "Cvss": [
+                {
+                    "BaseScore": 7.5,
+                    "BaseVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                    "Source": "UBUNTU_CVE",
+                    "Version": "3.1"
+                },
+                {
+                    "BaseScore": 7.5,
+                    "BaseVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                    "Source": "NVD",
+                    "Version": "3.1"
+                },
+                {
+                    "BaseScore": 7.5,
+                    "BaseVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                    "Source": "UBUNTU_CVE",
+                    "Version": "3.1"
+                }
+            ],
+            "EpssScore": 0.01559,
+            "ExploitAvailable": "NO",
+            "FixAvailable": "YES",
+            "Id": "CVE-2021-3737",
+            "ReferenceUrls": [
+                "https://ubuntu.com/security/notices/USN-5083-1",
+                "https://ubuntu.com/security/notices/USN-5201-1",
+                "https://ubuntu.com/security/notices/USN-5200-1",
+                "https://ubuntu.com/security/notices/USN-6891-1",
+                "https://bugs.python.org/issue44022",
+                "https://www.cve.org/CVERecord?id=CVE-2021-3737",
+                "https://ubuntu.com/security/notices/USN-5199-1"
+            ],
+            "RelatedVulnerabilities": [
+                "USN-5200-1",
+                "USN-5201-1",
+                "USN-5083-1",
+                "USN-6891-1",
+                "USN-5199-1"
+            ],
+            "Vendor": {
+                "VendorCreatedAt": "2022-03-04T19:15:00.000Z",
+                "VendorSeverity": "medium",
+                "Url": "https://people.canonical.com/~ubuntu-security/cve/2021/CVE-2021-3737.html",
+                "Name": "UBUNTU_CVE"
+            },
+            "VulnerablePackages": [
+                {
+                    "Architecture": "X86_64",
+                    "PackageManager": "OS",
+                    "Version": "3.10.6",
+                    "Epoch": "0",
+                    "FixedInVersion": "0:3.10.12-1~22.04.4",
+                    "Remediation": "apt-get update && apt-get upgrade",
+                    "Release": "1~22.04.2ubuntu1.1",
+                    "Name": "python3.10"
+                },
+                {
+                    "Architecture": "X86_64",
+                    "PackageManager": "OS",
+                    "Version": "3.10.6",
+                    "Epoch": "0",
+                    "FixedInVersion": "0:3.10.12-1~22.04.4",
+                    "Remediation": "apt-get update && apt-get upgrade",
+                    "Release": "1~22.04.2ubuntu1.1",
+                    "Name": "python3.10-minimal"
+                }
+            ]
+        }
+    ],
+    "Workflow": {
+        "Status": "NEW"
+    },
+    "WorkflowState": "NEW"
   }
 ]

--- a/tests/fixtures/suppressions/full.yaml
+++ b/tests/fixtures/suppressions/full.yaml
@@ -20,3 +20,10 @@ Rules:
       resource_id_regexps:
         - '^arn:aws:s3:::.*-dev$'
         - '^arn:aws:s3:::.*-acc$'
+  - note: 'We support Inspector too'
+    action: 'SUPPRESSED'
+    match_on:
+      product_name: 'Inspector'
+      title: 'CVE-2021-3737 - python3.10, python3.10-minimal'
+      resource_id_regexps:
+        - '^arn:aws:ec2:.*:.*:instance/.*$'

--- a/tests/test_suppressions.py
+++ b/tests/test_suppressions.py
@@ -55,21 +55,21 @@ with open('tests/fixtures/batch_update_findings_full.json', encoding='utf-8') as
     batch_update_findings_full_fixture = json.load(updates_file)
 
 full_findings_fixture = []
-for security_control_id in ['S3.8', 'S3.9', 'S3.14', 'S3.20']:
+for identifier in ['S3.8', 'S3.9', 'S3.14', 'S3.20', 'Inspector']:
     for env in ['dev', 'acc', 'prd']:
-        with open(f'tests/fixtures/findings/full/{security_control_id}/{env}.json', encoding='utf-8') as findings_file:
+        with open(f'tests/fixtures/findings/full/{identifier}/{env}.json', encoding='utf-8') as findings_file:
             full_findings_fixture.append(json.load(findings_file))
 
 # this one goes together with a query based on suppressions/full.yaml
-findings_by_security_control_id_fixture = {}
+findings_by_identifier_fixture = {}
 # there is no id S3.8 suppression in suppressions/full.yaml
-for security_control_id in ['S3.9', 'S3.14', 'S3.20']:
-    findings_by_security_control_id_fixture[security_control_id] = []
+for identifier in ['S3.9', 'S3.14', 'S3.20', 'Inspector']:
+    findings_by_identifier_fixture[identifier] = []
     # a query with tags already filters out the non-conforming ones,
     # hence no dev for S3.14
-    for env in ['dev', 'acc', 'prd'] if security_control_id != 'S3.14' else ['acc', 'prd']:
-        with open(f'tests/fixtures/findings/full/{security_control_id}/{env}.json', encoding='utf-8') as findings_file:
-            findings_by_security_control_id_fixture[security_control_id].append(
+    for env in ['dev', 'acc', 'prd'] if identifier != 'S3.14' else ['acc', 'prd']:
+        with open(f'tests/fixtures/findings/full/{identifier}/{env}.json', encoding='utf-8') as findings_file:
+            findings_by_identifier_fixture[identifier].append(
                 json.load(findings_file))
 
 with open('tests/fixtures/matches.json', encoding='utf-8') as matches_file:
@@ -147,7 +147,7 @@ class TestFullSuppressions(FindingsManagerTestCase):
     @patch(
         'awsfindingsmanagerlib.FindingsManager._get_security_hub_paginator_iterator',
         lambda *_, **kwargs: [{
-            'Findings': findings_by_security_control_id_fixture[kwargs['query_filter']['ComplianceSecurityControlId'][0]['Value']]
+            'Findings': findings_by_identifier_fixture[kwargs['query_filter']['ComplianceSecurityControlId'][0]['Value'] if 'ComplianceSecurityControlId' in kwargs['query_filter'] else kwargs['query_filter']['ProductName'][0]['Value']]
         }],
     )
     @patch('awsfindingsmanagerlib.FindingsManager._batch_update_findings', side_effect=batch_update_findings_mock)


### PR DESCRIPTION
This PR proposes adding support for suppressing findings coming from [Security Hub integrations with other AWS services](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-internal-providers.html#internal-integrations-summary).

Findings detected by other services (e.g. Amazon Inspector) miss the key attribute currently used to query findings that should be suppressed: `ControlId`.

A JSON example of an Inspector finding can be found in the [fixtures folder](https://github.com/schubergphilis/awsfindingsmanagerlib/blob/sechub_integrations_findings/tests/fixtures/findings/full/Inspector/dev.json).

To overcome that limitation, this PR proposes adding support for 2 new suppression fields:

- `product_name`: this field contains the name of the product that has created the finding (e.g. `Inspector`).
- `title`: this field contains the title of the finding.

By combining these 2 extra fields, we would be able to suppress findings coming from any other service that integrates with Security Hub.

And by leveraging the resource ID regex feature, we have full control to make make those suppressions more or less permissive.