### PR TITLE
chore: updates default SecurityHub filter

### DIFF
--- a/awsfindingsmanagerlib/configuration.py
+++ b/awsfindingsmanagerlib/configuration.py
@@ -49,12 +49,12 @@ LOGGER.addHandler(logging.NullHandler())
 DEFAULT_SECURITY_HUB_FILTER = {
     'WorkflowStatus': [
         {
-            'Value': 'SUPPRESSED',
-            'Comparison': 'NOT_EQUALS'
+            'Value': 'NEW',
+            'Comparison': 'EQUALS'
         },
         {
-            'Value': 'RESOLVED',
-            'Comparison': 'NOT_EQUALS'
+            'Value': 'NOTIFIED',
+            'Comparison': 'EQUALS'
         }
     ]
 }

--- a/awsfindingsmanagerlib/configuration.py
+++ b/awsfindingsmanagerlib/configuration.py
@@ -46,16 +46,18 @@ LOGGER_BASENAME = '''configuration'''
 LOGGER = logging.getLogger(LOGGER_BASENAME)
 LOGGER.addHandler(logging.NullHandler())
 
-DEFAULT_SECURITY_HUB_FILTER = {'ComplianceStatus': [
-    {
-        'Value': 'FAILED',
-        'Comparison': 'EQUALS'
-    },
-    {
-        'Value': 'WARNING',
-        'Comparison': 'EQUALS'
-    }
-]}
+DEFAULT_SECURITY_HUB_FILTER = {
+    'WorkflowStatus': [
+        {
+            'Value': 'SUPPRESSED',
+            'Comparison': 'NOT_EQUALS'
+        },
+        {
+            'Value': 'RESOLVED',
+            'Comparison': 'NOT_EQUALS'
+        }
+    ]
+}
 
 
 def get_available_security_hub_regions():


### PR DESCRIPTION
This PR changes the default SecurityHub filter so it uses `WorkflowStatus` instead of `ComplianceStatus` as initial filtering criteria.

The reason behind this proposal is twofold:

- `ComplianceStatus` is not available in findings coming from integrated services such as GuardDuty and Inspector. This means that these findings are never returned by the current query and can't be suppressed.
- the final indicator that a finding that matches a suppression rule is still not suppressed is having `WorkflowStatus` different than `SUPPRESSED` or `RESOLVED`.

With the current filter structure, the support for SecurityHub integrations is not working.